### PR TITLE
Implemented "JazzFuzzRules"

### DIFF
--- a/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/.gitignore
+++ b/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/contentModel.xml
+/modules.xml
+/.idea.Frank.FizzBuzzJazzFuzz.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/encodings.xml
+++ b/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/indexLayout.xml
+++ b/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/vcs.xml
+++ b/.idea/.idea.Frank.FizzBuzzJazzFuzz/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,11 +6,24 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
+  <PropertyGroup Label="NuGet compatibility">
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1504;NU1510;NU1603;NU1605;NU1608;NU1901;NU1902;NU1903;NU1904;NU1701</WarningsNotAsErrors>
+  </PropertyGroup>
+
   <PropertyGroup Label="Artifacts">
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
   </PropertyGroup>
   <PropertyGroup Label="Continuous integration" Condition="'$(CI)' == 'true' Or '$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Nullable and legacy warnings">
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS0067;CS0108;CS0168;CS0219;CS0433;CS4014;CS1574;CS1717;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8619;CS8620;CS8625;CS8629;CS8631;CS8632;CS8765;DV2001;RS1014</WarningsNotAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(MSBuildProjectDirectory.Contains('.Tests'))">
+    <NoWarn>$(NoWarn);CA1001;CA1051;CA1062;CA1707;CA1716;CA2007;CA2200;CA2234;xUnit1008;xUnit1013;xUnit1026</NoWarn>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup Label="Build quality">
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1711</NoWarn>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  <PropertyGroup Label="Artifacts">
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+  </PropertyGroup>
+  <PropertyGroup Label="Continuous integration" Condition="'$(CI)' == 'true' Or '$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Shared targets; extend as needed (see RoboSharp pattern). -->
+</Project>

--- a/Frank.FizzBuzzJazzFuzz.Cli/Frank.FizzBuzzJazzFuzz.Cli.csproj
+++ b/Frank.FizzBuzzJazzFuzz.Cli/Frank.FizzBuzzJazzFuzz.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Frank.FizzBuzzJazzFuzz.Cli/Program.cs
+++ b/Frank.FizzBuzzJazzFuzz.Cli/Program.cs
@@ -4,6 +4,7 @@ using Frank.FizzBuzzJazzFuzz.Models;
 using Frank.FizzBuzzJazzFuzz.Rules;
 
 var rules = new FizzBuzzRules();
+
 var result = rules.RunRules(new UintRange(1, 100));
 
 Console.WriteLine(string.Join("\n", result));

--- a/Frank.FizzBuzzJazzFuzz.FizzBuzz/Extensions/RuleExtensions.cs
+++ b/Frank.FizzBuzzJazzFuzz.FizzBuzz/Extensions/RuleExtensions.cs
@@ -5,4 +5,6 @@ namespace Frank.FizzBuzzJazzFuzz.Extensions;
 public static class RuleExtensions
 {
     public static string RunRule(this Rule rule, uint value) => value % rule.Divisor == 0 ? rule.Text : string.Empty;
+
+    // public static string RunRuleV2(this RuleV2 rule, uint value) => rule.Calculation.Invoke(value) ? rule.Text : string.Empty;
 }

--- a/Frank.FizzBuzzJazzFuzz.FizzBuzz/Frank.FizzBuzzJazzFuzz.csproj
+++ b/Frank.FizzBuzzJazzFuzz.FizzBuzz/Frank.FizzBuzzJazzFuzz.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Frank.FizzBuzzJazzFuzz.FizzBuzz/Models/Rule.cs
+++ b/Frank.FizzBuzzJazzFuzz.FizzBuzz/Models/Rule.cs
@@ -6,3 +6,5 @@
 /// <param name="Divisor">What the integer value will be attempted to be divided with</param>
 /// <param name="Text">The text that will replace the integer value if the rule is "true"</param>
 public readonly record struct Rule(uint Divisor, string Text);
+
+public readonly record struct RuleV2(Func<uint, uint, bool> Calculation, string Text);

--- a/Frank.FizzBuzzJazzFuzz.FizzBuzz/Rules/JazzFuzzRules.cs
+++ b/Frank.FizzBuzzJazzFuzz.FizzBuzz/Rules/JazzFuzzRules.cs
@@ -1,0 +1,12 @@
+﻿using Frank.FizzBuzzJazzFuzz.Models;
+
+namespace Frank.FizzBuzzJazzFuzz.Rules;
+
+public class JazzFuzzRules : RulesBase
+{
+    public JazzFuzzRules()
+    {
+        AddRule(new Rule(9, "Jazz"));
+        AddRule(new Rule(4, "Fuzz"));
+    }
+}

--- a/Frank.FizzBuzzJazzFuzz.FizzBuzz/Rules/RulesBase.cs
+++ b/Frank.FizzBuzzJazzFuzz.FizzBuzz/Rules/RulesBase.cs
@@ -33,7 +33,7 @@ public abstract class RulesBase : IRules
     public List<string> RunRules(UintRange range)
     {
         var output = new List<string>();
-
+        var input = Enumerable.Range((int)range.Start, (int)range.End).Reverse();
         if (range.Start <= range.End)
             for (var i = range.Start; i <= range.End; i++)
                 output.Add(RunRules(i));

--- a/Frank.FizzBuzzJazzFuzz.Tests/Extensions/RuleExtensionsTests.cs
+++ b/Frank.FizzBuzzJazzFuzz.Tests/Extensions/RuleExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿using Frank.FizzBuzzJazzFuzz.Extensions;
+using Frank.FizzBuzzJazzFuzz.Models;
+
+namespace Frank.FizzBuzzJazzFuzz.Tests.Extensions;
+
+public class RuleExtensionsTests
+{
+    //[Fact]
+    //public void RunRule_StateUnderTest_ExpectedBehavior()
+    //{
+    //	// Arrange
+    //	var ruleExtensions = new RuleExtensions();
+    //	Rule rule = default(global::Frank.FizzBuzzJazzFuzz.Models.Rule);
+    //	uint value = 0;
+
+    //	// Act
+    //	var result = ruleExtensions.RunRule(
+    //		rule,
+    //		value);
+
+    //	// Assert
+    //	Assert.True(false);
+    //}
+
+    [Fact]
+    public void RunRuleV2_StateUnderTest_ExpectedBehavior()
+    {
+        // Arrange
+        var rule = new RuleV2((x, y) => x % y == 0, "");
+        uint value = 0;
+
+        // Act
+        // var result = rule.RunRuleV2(rule, value);
+
+        // Assert
+        Assert.True(false);
+    }
+}

--- a/Frank.FizzBuzzJazzFuzz.Tests/Frank.FizzBuzzJazzFuzz.Tests.csproj
+++ b/Frank.FizzBuzzJazzFuzz.Tests/Frank.FizzBuzzJazzFuzz.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Frank.FizzBuzzJazzFuzz.Tests/IntegerRangeAnalyzerTests.cs
+++ b/Frank.FizzBuzzJazzFuzz.Tests/IntegerRangeAnalyzerTests.cs
@@ -8,7 +8,7 @@ namespace Frank.FizzBuzzJazzFuzz.Tests;
 public class IntegerRangeAnalyzerTests
 {
     [Fact]
-    public void Analyze_Instance()
+    public void AnalyzeFizzBuzz_Instance()
     {
         // Arrange
         var integerRangeAnalyzer = new IntegerRangeAnalyzer(new FizzBuzzRules());
@@ -23,7 +23,7 @@ public class IntegerRangeAnalyzerTests
     }
 
     [Fact]
-    public void Analyze_Static()
+    public void AnalyzeFizzBuzz_Static()
     {
         // Arrange
         var rules = new FizzBuzzRules();

--- a/Frank.FizzBuzzJazzFuzz.Tests/IntegerRangeAnalyzerTests.cs
+++ b/Frank.FizzBuzzJazzFuzz.Tests/IntegerRangeAnalyzerTests.cs
@@ -1,9 +1,21 @@
-﻿using FluentAssertions;
+﻿using System.Numerics;
+
+using FluentAssertions;
 
 using Frank.FizzBuzzJazzFuzz.Models;
 using Frank.FizzBuzzJazzFuzz.Rules;
 
 namespace Frank.FizzBuzzJazzFuzz.Tests;
+
+public static class MathConstants
+{
+    public static Single Deg2Rad = 0.01745329f;
+}
+
+public static class MathExtensions
+{
+    public static T Deg2Rad<T>(this T source) where T : class, INumber<T> => source * (MathConstants.Deg2Rad as T);
+}
 
 public class IntegerRangeAnalyzerTests
 {

--- a/Frank.FizzBuzzJazzFuzz.Tests/Rules/JazzFuzzRulesTests.cs
+++ b/Frank.FizzBuzzJazzFuzz.Tests/Rules/JazzFuzzRulesTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+
+using Frank.FizzBuzzJazzFuzz.Models;
+using Frank.FizzBuzzJazzFuzz.Rules;
+
+namespace Frank.FizzBuzzJazzFuzz.Tests.Rules;
+
+public class JazzFuzzRulesTests
+{
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(1, "1")]
+    [InlineData(2, "2")]
+    [InlineData(3, "3")]
+    [InlineData(4, "Fuzz")]
+    [InlineData(5, "5")]
+    [InlineData(6, "6")]
+    [InlineData(7, "7")]
+    [InlineData(8, "Fuzz")]
+    [InlineData(9, "Jazz")]
+    [InlineData(10, "10")]
+    public void RunRules_SingleValue(uint value, string expected)
+    {
+        // Arrange
+        var jazzFuzzRules = new JazzFuzzRules();
+
+        // Act
+        var result = jazzFuzzRules.RunRules(value);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, 100, 100, 1)]
+    public void RunRules_RangeValue(uint from1, uint to1, uint from2, uint to2)
+    {
+        // Arrange
+        var fizzBuzzRules = new FizzBuzzRules();
+        var jazzFuzzRules = new JazzFuzzRules();
+        var range1 = new UintRange(from1, to1);
+        var range2 = new UintRange(from2, to2);
+        var expected = File.ReadAllLines("Files/FizzBuzzJazzFuzz.txt");
+
+        // Act
+        var result1 = fizzBuzzRules.RunRules(range1);
+        var result2 = jazzFuzzRules.RunRules(range2);
+        var result = result1.Concat(result2);
+
+        // Assert
+        result.Should().Equal(expected);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.201",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Added a default rule for JazzFuzz and tests to check against the file with the "truth" in it, and it matched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the entire solution to .NET 10 and tightens build settings (warnings-as-errors), which can break CI/builds across environments; the added placeholder test currently fails and would block merges if tests run.
> 
> **Overview**
> Adds a new `JazzFuzzRules` ruleset (divisible by 9 => "Jazz", divisible by 4 => "Fuzz") and corresponding xUnit/FluentAssertions tests that validate both single values and a combined FizzBuzz+JazzFuzz output against a golden file.
> 
> Upgrades all projects to `net10.0`, introduces repo-wide build settings via `Directory.Build.props` (warnings-as-errors, analyzers, artifacts output, CI build flag) plus a `global.json` pinning .NET SDK `10.0.201`. Also includes a small, currently-unused `RuleV2` experiment and a placeholder failing test, plus some IDE (`.idea`) metadata committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f1e76de170c1af0a630051d1e3d9fcb07dcf747. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->